### PR TITLE
example arguments, sort sci_files, pdf filename

### DIFF
--- a/examples/IRDIFS-reduction.ipynb
+++ b/examples/IRDIFS-reduction.ipynb
@@ -347,7 +347,7 @@
    "outputs": [],
    "source": [
     "# generate individual (x,y,lambda) cubes\n",
-    "reduction.sph_ifs_science_cubes(postprocess=True, silent=True)"
+    "reduction.sph_ifs_science_cubes(silent=True)"
    ]
   },
   {
@@ -378,7 +378,7 @@
    "source": [
     "# combine data in (x,y,time,lambda) cubes\n",
     "reduction.sph_ifs_combine_data(cpix=True, psf_dim=80, science_dim=290, correct_anamorphism=True, \n",
-    "                               shift_method='fft', nocenter=False, save_scaled=False)"
+    "                               shift_method='fft', save_scaled=False)"
    ]
   },
   {

--- a/vltpf/IFS.py
+++ b/vltpf/IFS.py
@@ -2009,7 +2009,7 @@ class Reduction(object):
             raise ValueError('Unknown IFS mode {0}'.format(mode))
 
         # get list of science files
-        sci_files = glob.glob(path.preproc+'*_preproc.fits')
+        sci_files = sorted(glob.glob(path.preproc+'*_preproc.fits'))
         print(' * found {0} pre-processed files'.format(len(sci_files)))
 
         # get list of calibration files
@@ -2316,7 +2316,7 @@ class Reduction(object):
         ax.set_title('Wavelength calibration')
         plt.tight_layout()
 
-        plt.savefig(os.path.join(path.products, 'wavelegnth_recalibration.pdf'))
+        plt.savefig(os.path.join(path.products, 'wavelength_recalibration.pdf'))
 
         # update recipe execution
         self._recipe_execution['sph_ifs_wavelength_recalibration'] = True


### PR DESCRIPTION
Hi @avigan,

Thanks a lot for providing this SPHERE pipeline. I started to use it this week and it works really well!

While going through the IFS example, I made a few small fixes:

- There were two arguments in the IFS example which no longer existed.
- I got an esorex error ([error.log](https://github.com/avigan/VLTPF/files/3509086/error.log)) when running `sph_ifs_science_cubes` which I think appeared because the IFS_SCIENCE_DR_RAW files in science.sof were not sorted in time. Sorting the `sci_files` solved this problem.
- Typo in one of the PDF output files.