### PR TITLE
instru_offset added to the derotation angles

### DIFF
--- a/vltpf/toolbox.py
+++ b/vltpf/toolbox.py
@@ -230,7 +230,7 @@ def compute_angles(frames_info):
     frames_info['PUPIL OFFSET'] = pupoff + instru_offset
 
     # final derotation value
-    frames_info['DEROT ANGLE'] = frames_info['PARANG'] + pupoff
+    frames_info['DEROT ANGLE'] = frames_info['PARANG'] + pupoff + instru_offset
     
 
 def compute_bad_pixel_map(bpm_files, dtype=np.uint8):


### PR DESCRIPTION
The instrument offset was not included with the derotation angles (or was this done on purpose?), causing a 100 deg difference in field of view orientation between derotated IRDIS and IFS data.