### PR TITLE
Bug fix for configfile and wave_file

### DIFF
--- a/examples/irdis_spectro_reduction.py
+++ b/examples/irdis_spectro_reduction.py
@@ -30,7 +30,7 @@ reduction.check_files_association()
 #%% static calibrations
 reduction.sph_ird_cal_dark(silent=True)
 reduction.sph_ird_cal_detector_flat(silent=True)
-reduction.sph_ird_wave_calib(silent=True)
+reduction.sph_ird_cal_wave(silent=True)
 
 #%% science pre-processing
 reduction.sph_ird_preprocess_science(subtract_background=True, fix_badpix=True,

--- a/vltpf/IFS.py
+++ b/vltpf/IFS.py
@@ -466,7 +466,7 @@ class Reduction(object):
         # configuration
         #
         reduction._logger.debug('> read default configuration')
-        configfile = Path(vltpf.__file__).parent / 'instruments' / '{}.ini'.format(reduction._instrument)
+        configfile = f'{Path(vltpf.__file__).parent}/instruments/{reduction._instrument}.ini'
         config = configparser.ConfigParser()
 
         reduction._logger.debug('Read configuration')

--- a/vltpf/IFS.py
+++ b/vltpf/IFS.py
@@ -834,7 +834,7 @@ class Reduction(object):
                 file = list(path.preproc.glob('{}.fits'.format(fname)))
                 done = done and (len(file) == 1)
             if done:
-                self._update_recipe_status('sph_ifs_preprocess_wave', vltpf.SUCCESS)
+                self._update_recipe_status('sph_ifs_preprocess_science', vltpf.SUCCESS)
             self._logger.debug('> sph_ifs_preprocess_science status = {}'.format(done))
             
             done = True

--- a/vltpf/IRDIS/ImagingReduction.py
+++ b/vltpf/IRDIS/ImagingReduction.py
@@ -126,7 +126,7 @@ class ImagingReduction(object):
         #
         # configuration
         #
-        configfile = Path(vltpf.__file__).parent / 'instruments' / '{}.ini'.format(reduction._instrument)
+        configfile = f'{Path(vltpf.__file__).parent}/instruments/{reduction._instrument}.ini'
         config = configparser.ConfigParser()
 
         reduction._logger.debug('> read default configuration')

--- a/vltpf/IRDIS/SpectroReduction.py
+++ b/vltpf/IRDIS/SpectroReduction.py
@@ -170,7 +170,7 @@ class SpectroReduction(object):
         #
         # configuration
         #
-        configfile = Path(vltpf.__file__).parent / 'instruments' / '{}.ini'.format(reduction._instrument)
+        configfile = f'{Path(vltpf.__file__).parent}/instruments/{reduction._instrument}.ini'
         config = configparser.ConfigParser()
 
         reduction._logger.debug('> read configuration')
@@ -1214,7 +1214,7 @@ class SpectroReduction(object):
             self._logger.debug('> create sof file')
             sof = path.sof / 'wave.sof'
             file = open(sof, 'w')
-            file.write('{0}/{1}.fits     {2}\n'.format(path.raw, wave_file, 'IRD_WAVECALIB_RAW'))
+            file.write('{0}/{1}.fits     {2}\n'.format(path.raw, wave_file.index[0], 'IRD_WAVECALIB_RAW'))
             file.write('{0}/{1}.fits     {2}\n'.format(path.calib, dark_file.index[0], 'IRD_MASTER_DARK'))
             file.write('{0}/{1}.fits     {2}\n'.format(path.calib, flat_file.index[0], 'IRD_FLAT_FIELD'))
             file.write('{0}/{1}.fits     {2}\n'.format(path.calib, bpm_file.index[0], 'IRD_STATIC_BADPIXELMAP'))

--- a/vltpf/IRDIS/SpectroReduction.py
+++ b/vltpf/IRDIS/SpectroReduction.py
@@ -1073,6 +1073,15 @@ class SpectroReduction(object):
         filter_combs = calibs['INS COMB IFLT'].unique()
 
         for cfilt in filter_combs:
+            for i, dpr_tech in enumerate(calibs['DPR TECH']):
+                if dpr_tech != 'SPECTRUM':
+                    date_obs = calibs['DATE-OBS'][i]
+
+                    self._logger.warning(f'The \'DPR TECH\' value of the flat calibration '
+                                         f'obtained on {date_obs} is {dpr_tech}. It is '
+                                         f'recommended to use flat calibrations for which '
+                                         f'the \'DPR TECH\' is \'SPECTRUM\'.')
+
             cfiles = calibs[calibs['INS COMB IFLT'] == cfilt]
             files = cfiles.index
 
@@ -1982,8 +1991,8 @@ class SpectroReduction(object):
                 wave = fits.getdata(wfile)
             else:
                 self._logger.error('Missing default or recalibrated wavelength calibration. You must first run either sph_ird_cal_wave or sph_ird_wavelength_recalibration().')
-            self._update_recipe_status('sph_ird_combine_data', vltpf.ERROR)
-            return
+                self._update_recipe_status('sph_ird_combine_data', vltpf.ERROR)
+                return
 
         # wavelength solution: make sure we have the same number of
         # wave points in each field


### PR DESCRIPTION
- The `configparser` caused an error because `configfile` was a `Path` object instead of a string.
- The name of the `wave_file` was incorrectly passed in `sph_ird_cal_wave` with `S_LR`.
- Changed `sph_ird_wave_calib` to `sph_ird_cal_wave` in the `SpectroReduction` example.