### PR TITLE
Compatibility with recent versions of numpy, astropy, and pandas

### DIFF
--- a/sphere/IRDIS/ImagingReduction.py
+++ b/sphere/IRDIS/ImagingReduction.py
@@ -1334,7 +1334,10 @@ class ImagingReduction(object):
                         return
                     
                     # merge frames info
-                    frames_info_preproc = pd.concat((frames_info_preproc, frames_info_new))
+                    if frames_info_preproc.size > 0:
+                        frames_info_preproc = pd.concat((frames_info_preproc, frames_info_new))
+                    else:
+                        frames_info_preproc = frames_info_new.copy()
 
                     # background subtraction
                     if subtract_background:

--- a/sphere/IRDIS/SpectroReduction.py
+++ b/sphere/IRDIS/SpectroReduction.py
@@ -2102,7 +2102,7 @@ class SpectroReduction(object):
 
             self._logger.warning('Images will be centered using the user-provided center ({},{})'.format(*manual_center))
 
-            manual_center = np.full((1024, 2), manual_center, dtype=np.float)
+            manual_center = np.full((1024, 2), manual_center, dtype=np.float64)
 
         #
         # OBJECT,FLUX
@@ -2137,7 +2137,7 @@ class SpectroReduction(object):
                     centers = fits.getdata(cfile)
                 else:
                     self._logger.warning('sph_ird_star_center() has not been executed. Images will be centered using default centers ({}, {})'.format(*default_center[:, 0]))
-                    centers = np.full((1024, 2), default_center[:, 0], dtype=np.float)
+                    centers = np.full((1024, 2), default_center[:, 0], dtype=np.float64)
 
                 # make sure we have only integers if user wants coarse centering
                 if coarse_centering:
@@ -2156,7 +2156,7 @@ class SpectroReduction(object):
 
                     if correct_mrs_chromatism and (filter_comb == 'S_MR'):
                         self._logger.debug('> correct MRS chromatism')
-                        img = img.astype(np.float)
+                        img = img.astype(np.float64)
                         self._logger.debug('> shift and normalize')
                         for wave_idx, widx in enumerate(ciwave):
                             cx = centers[widx, field_idx]
@@ -2171,7 +2171,7 @@ class SpectroReduction(object):
                         cx = centers[ciwave, field_idx].mean()
 
                         self._logger.debug('> shift and normalize')
-                        img  = img.astype(np.float)
+                        img  = img.astype(np.float64)
                         nimg = imutils.shift(img, (cc-cx, 0), method=shift_method)
                         nimg = nimg / DIT
 
@@ -2260,7 +2260,7 @@ class SpectroReduction(object):
 
                     if correct_mrs_chromatism and (filter_comb == 'S_MR'):
                         self._logger.debug('> correct MRS chromatism')
-                        img = img.astype(np.float)
+                        img = img.astype(np.float64)
                         self._logger.debug('> shift and normalize')
                         for wave_idx, widx in enumerate(ciwave):
                             cx = centers[widx, field_idx]
@@ -2274,7 +2274,7 @@ class SpectroReduction(object):
                         cx = centers[ciwave, field_idx].mean()
 
                         self._logger.debug('> shift and normalize')
-                        img  = img.astype(np.float)
+                        img  = img.astype(np.float64)
                         nimg = imutils.shift(img, (cc-cx, 0), method=shift_method)
                         nimg = nimg / DIT
 
@@ -2337,7 +2337,7 @@ class SpectroReduction(object):
                 # use manual center if explicitely requested
                 self._logger.debug('> read centers')
                 if manual_center is not None:
-                    centers = np.full((1024, 2), manual_center, dtype=np.float)
+                    centers = np.full((1024, 2), manual_center, dtype=np.float64)
                 else:
                     # otherwise, look whether we have an OBJECT,CENTER frame and select the one requested by user
                     starcen_files = frames_info[frames_info['DPR TYPE'] == 'OBJECT,CENTER']
@@ -2366,7 +2366,7 @@ class SpectroReduction(object):
                             centers = fits.getdata(fpath)
                         else:
                             self._logger.warning('sph_ird_star_center() has not been executed. Images will be centered using default center ({},{})'.format(*self._default_center))
-                            centers = np.full((1024, 2), default_center[:, 0], dtype=np.float)
+                            centers = np.full((1024, 2), default_center[:, 0], dtype=np.float64)
 
                 # make sure we have only integers if user wants coarse centering
                 if coarse_centering:
@@ -2390,7 +2390,7 @@ class SpectroReduction(object):
 
                     if correct_mrs_chromatism and (filter_comb == 'S_MR'):
                         self._logger.debug('> correct MRS chromatism')
-                        img = img.astype(np.float)
+                        img = img.astype(np.float64)
                         self._logger.debug('> shift and normalize')
                         for wave_idx, widx in enumerate(ciwave):
                             cx = centers[widx, field_idx]
@@ -2404,7 +2404,7 @@ class SpectroReduction(object):
                         cx = centers[ciwave, field_idx].mean()
 
                         self._logger.debug('> shift and normalize')
-                        img  = img.astype(np.float)
+                        img  = img.astype(np.float64)
                         nimg = imutils.shift(img, (cc-cx, 0), method=shift_method)
                         nimg = nimg / DIT
 

--- a/sphere/utils/imutils.py
+++ b/sphere/utils/imutils.py
@@ -570,7 +570,7 @@ def _scale_fft(array, scale_value, alt_criterion=False):
     # Compared to the ALTernate criterion below, this one favors small
     # values of N" i.e. little truncation in Fourier space.  
     kd_array = np.arange(dim/2 + 1, dtype=np.int)
-    yy = dim/2 * (zoom_io - 1) + kd_array.astype(np.float)*zoom_io
+    yy = dim/2 * (zoom_io - 1) + kd_array.astype(np.float64)*zoom_io
     kf_array = np.round(yy).astype(np.int)
 
     tmp = np.abs(yy-kf_array)
@@ -861,7 +861,7 @@ def sigma_filter(img, box=5, nsigma=3, iterate=False, return_mask=False, max_ite
 
     # create _mask at first iteration
     if _mask is None:
-        _mask = np.zeros_like(img, dtype=np.bool)
+        _mask = np.zeros_like(img, dtype=np.bool_)
 
     # identify clipped pixels
     _mask[img != img_clip] = True

--- a/sphere/utils/toolbox.py
+++ b/sphere/utils/toolbox.py
@@ -765,7 +765,7 @@ def star_centers_from_PSF_lss_cube(cube, wave_cube, pixel, high_pass=False, box_
 
         # approximate center
         prof = np.sum(img, axis=0)
-        cx_int = int(np.argmax(prof))
+        cx_int = np.int64(np.argmax(prof))
 
         # sub-image
         sub = img[:, cx_int-box:cx_int+box]

--- a/sphere/utils/toolbox.py
+++ b/sphere/utils/toolbox.py
@@ -626,7 +626,7 @@ def star_centers_from_PSF_img_cube(cube, wave, pixel, exclude_fraction=0.1, high
                                    x_stddev=loD[idx], y_stddev=loD[idx]) + \
                                    models.Const2D(amplitude=sub.min())
         fitter = fitting.LevMarLSQFitter()
-        par = fitter(g_init, xx, yy, sub)
+        par = fitter(g_init, xx, yy, sub, maxiter=1000)
         
         cx_final = cx - box + par[0].x_mean
         cy_final = cy - box + par[0].y_mean
@@ -976,7 +976,7 @@ def star_centers_from_waffle_img_cube(cube_cen, wave, waffle_orientation, center
                                        x_stddev=loD[idx], y_stddev=loD[idx], bounds=gbounds) + \
                                        models.Const2D(amplitude=sub.min())
             fitter = fitting.LevMarLSQFitter()
-            par = fitter(g_init, xx, yy, sub)
+            par = fitter(g_init, xx, yy, sub, maxiter=1000)
             fit = par(xx, yy)
 
             cx_final = cx - box + par[0].x_mean

--- a/sphere/utils/transmission.py
+++ b/sphere/utils/transmission.py
@@ -175,7 +175,7 @@ def _load(type, name):
         # load data
         dfw_tr_tmp = np.loadtxt(filter_file, unpack=False).T
 
-        dfw_tr = np.zeros((2, wave_grid.size), dtype=np.float)
+        dfw_tr = np.zeros((2, wave_grid.size), dtype=np.float64)
         dfw_tr[0] = _reinterpolate(dfw_tr_tmp[1], dfw_tr_tmp[0], wave_grid)
         dfw_tr[1] = _reinterpolate(dfw_tr_tmp[2], dfw_tr_tmp[0], wave_grid)
 


### PR DESCRIPTION
Hi @avigan,

I recently came across several errors by numpy, pandas, and astropy, and a FutureWarning by pandas. These occurred with recent versions of these libraries, and using Python 3.11.

- There are several data types of numpy that no longer exist.
- Setting `dtype=float` for the `DataFrame` no longer worked because some columns have `str` values, which was causing an error. Instead I used the generic `dtype=object` and let pandas infer the float columns later on with `infer_objects()`
- Creating an `Angle` from a tuple with values is no longer supported, so I added a for loop to create a list of `Angle` objects and then pass that list to `Angle` to create a single object with multiple angles (like the original implementation)
- Selecting a `DataFrame` row by index can in the future only be done with`.iloc[]` (instead of just `[]`)

I tested these changes on a dataset with a know companion and checked if the derotation angles were still the same. I think everything seems fine, but please have a look at the changes and let me know if you have any feedback!